### PR TITLE
Fix little bug in Nginx entrypoint.sh file

### DIFF
--- a/docker/nginx/entrypoint.sh
+++ b/docker/nginx/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Using environment variables to set nginx configuration
-[ -z "${PROJECT_NAME}" ] && echo "\$PROJECT_NAME is not set" || sed -i "s/PROJECT_NAME/${PROJECT_NAME}/" /etc/nginx/conf.d/default.conf
+[ -z "${PROJECT_NAME}" ] && echo "\$PROJECT_NAME is not set" || sed -i "s/PROJECT_NAME/${PROJECT_NAME}/g" /etc/nginx/conf.d/default.conf
 [ -z "${PROJECT_WEB_DIR}" ] && echo "\$PROJECT_WEB_DIR is not set" || sed -i "s/PROJECT_WEB_DIR/${PROJECT_WEB_DIR}/" /etc/nginx/conf.d/default.conf
 [ -z "${PROJECT_INDEX_FILE}" ] && echo "\$PROJECT_INDEX_FILE is not set" || sed -i "s/PROJECT_INDEX_FILE/${PROJECT_INDEX_FILE}/" /etc/nginx/conf.d/default.conf
 [ -z "${PROJECT_DEV_INDEX_FILE}" ] && echo "\$PROJECT_DEV_INDEX_FILE is not set" || sed -i "s/PROJECT_DEV_INDEX_FILE/${PROJECT_DEV_INDEX_FILE}/" /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Fix little bug in Nginx entrypoint.sh file - without /g script replaced only first PROJECT_NAME occur.