### PR TITLE
Changing owner/group of project dirs.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ php:
     - data
   environment:
     PROJECT_XDEBUG_ENABLED: ${PROJECT_XDEBUG_ENABLED}
+    PROJECT_USER_ID: ${PROJECT_USER_ID}
+    PROJECT_GROUP_ID: ${PROJECT_GROUP_ID}
 
 mysql:
   image: mysql:5.7

--- a/docker.sh
+++ b/docker.sh
@@ -5,11 +5,14 @@ PROJECT_PHP_VERSION=${2:-71};
 PROJECT_WITH_COVERAGE=${3:-false};
 
 export APP_NAME="pgsdemo"
-export APP_VERSION="0.0.1"
+export APP_VERSION="0.0.2"
+
 export PROJECT_NAME="$APP_NAME"
 export PROJECT_WEB_DIR=${PROJECT_WEB_DIR:="web"}
 export PROJECT_INDEX_FILE=${PROJECT_INDEX_FILE:="index.php"}
 export PROJECT_DEV_INDEX_FILE=${PROJECT_DEV_INDEX_FILE:="index_dev.php"}
+export PROJECT_USER_ID=$(id -u)
+export PROJECT_GROUP_ID=$(id -g)
 UUID=$(cat /proc/sys/kernel/random/uuid)
 export COMPOSE_PROJECT_NAME="${APP_NAME}-${UUID}"
 

--- a/docker/php56xdebug/Dockerfile
+++ b/docker/php56xdebug/Dockerfile
@@ -3,11 +3,10 @@ FROM php:5.6-fpm
 MAINTAINER Michał Kruczek <mkruczek@pgs-soft.com>
 
 RUN mkdir -p /var/www && \
-    chown -R www-data:www-data /var/www && \
     chmod 777 -R /var/www
 
 RUN apt-get -qq update --fix-missing && \
-    apt-get -q install -y \
+    apt-get -qq install -y \
         zlib1g-dev \
         libicu-dev \
         g++ \
@@ -43,6 +42,5 @@ COPY entrypoint.sh /entrypoint.sh
 
 VOLUME /var/www
 WORKDIR /var/www
-USER www-data
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/docker/php56xdebug/entrypoint.sh
+++ b/docker/php56xdebug/entrypoint.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+declare -i BUILD_STATUS=0;
 
 echo "PROJECT_XDEBUG_ENABLED = ${PROJECT_XDEBUG_ENABLED}"
 if [ $PROJECT_XDEBUG_ENABLED == false ]; then
@@ -8,5 +10,14 @@ fi
 
 if [ "$GITHUB_TOKEN" != "" ]; then composer config -g github-oauth.github.com ${GITHUB_TOKEN}; fi
 
-composer install --prefer-dist --no-interaction --no-progress
-phing
+if ! composer install --prefer-dist --no-interaction --no-progress; then
+    BUILD_STATUS=1
+fi
+
+if ! phing; then
+    BUILD_STATUS=1
+fi
+
+chown -R "${PROJECT_USER_ID}:${PROJECT_GROUP_ID}" .
+
+exit $BUILD_STATUS;

--- a/docker/php70xdebug/Dockerfile
+++ b/docker/php70xdebug/Dockerfile
@@ -3,11 +3,10 @@ FROM php:7.0-fpm
 MAINTAINER Michał Kruczek <mkruczek@pgs-soft.com>
 
 RUN mkdir -p /var/www && \
-    chown -R www-data:www-data /var/www && \
     chmod 777 -R /var/www
 
 RUN apt-get -qq update --fix-missing && \
-    apt-get -q install -y \
+    apt-get -qq install -y \
         zlib1g-dev \
         libicu-dev \
         g++ \
@@ -43,6 +42,5 @@ COPY entrypoint.sh /entrypoint.sh
 
 VOLUME /var/www
 WORKDIR /var/www
-USER www-data
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/docker/php70xdebug/entrypoint.sh
+++ b/docker/php70xdebug/entrypoint.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+declare -i BUILD_STATUS=0;
 
 echo "PROJECT_XDEBUG_ENABLED = ${PROJECT_XDEBUG_ENABLED}"
 if [ $PROJECT_XDEBUG_ENABLED == false ]; then
@@ -8,5 +10,14 @@ fi
 
 if [ "$GITHUB_TOKEN" != "" ]; then composer config -g github-oauth.github.com ${GITHUB_TOKEN}; fi
 
-composer install --prefer-dist --no-interaction --no-progress
-phing
+if ! composer install --prefer-dist --no-interaction --no-progress; then
+    BUILD_STATUS=1
+fi
+
+if ! phing; then
+    BUILD_STATUS=1
+fi
+
+chown -R "${PROJECT_USER_ID}:${PROJECT_GROUP_ID}" .
+
+exit $BUILD_STATUS;

--- a/docker/php71xdebug/Dockerfile
+++ b/docker/php71xdebug/Dockerfile
@@ -3,11 +3,10 @@ FROM php:7.1-fpm
 MAINTAINER Michał Kruczek <mkruczek@pgs-soft.com>
 
 RUN mkdir -p /var/www && \
-    chown -R www-data:www-data /var/www && \
     chmod 777 -R /var/www
 
 RUN apt-get -qq update --fix-missing && \
-    apt-get -q install -y \
+    apt-get -qq install -y \
         zlib1g-dev \
         libicu-dev \
         g++ \
@@ -43,6 +42,5 @@ COPY entrypoint.sh /entrypoint.sh
 
 VOLUME /var/www
 WORKDIR /var/www
-USER www-data
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/docker/php71xdebug/entrypoint.sh
+++ b/docker/php71xdebug/entrypoint.sh
@@ -1,6 +1,8 @@
-#!/bin/bash -e
+#!/bin/bash
 
-echo "PROJECT_XDEBUG_ENABLED = $PROJECT_XDEBUG_ENABLED"
+declare -i BUILD_STATUS=0;
+
+echo "PROJECT_XDEBUG_ENABLED = ${PROJECT_XDEBUG_ENABLED}"
 if [ $PROJECT_XDEBUG_ENABLED == false ]; then
     echo -e "Disabling xdebug\n";
     echo ';zend_extension=xdebug.so' > /usr/local/etc/php/conf.d/docker-php-pecl-xdebug.ini
@@ -8,5 +10,14 @@ fi
 
 if [ "$GITHUB_TOKEN" != "" ]; then composer config -g github-oauth.github.com ${GITHUB_TOKEN}; fi
 
-composer install --prefer-dist --no-interaction --no-progress
-phing
+if ! composer install --prefer-dist --no-interaction --no-progress; then
+    BUILD_STATUS=1
+fi
+
+if ! phing; then
+    BUILD_STATUS=1
+fi
+
+chown -R "${PROJECT_USER_ID}:${PROJECT_GROUP_ID}" .
+
+exit $BUILD_STATUS;


### PR DESCRIPTION
Get rid of `www-data` user. Thanks to that instead of changing `id` of `www-data` user to host user `id` `entrypoint.sh` is changing owner and group to host id after build. It resolves issues with permissions to dirs/files created by docker builds.

Known issues:
- e.g. when host user id is `0` or `root`


